### PR TITLE
Fix dynamic default in filter_entries

### DIFF
--- a/punch/__init__.py
+++ b/punch/__init__.py
@@ -53,7 +53,9 @@ def filter_todays_entries(entries):
     return filter_entries(entries, start, end)
 
 
-def filter_entries(entries, after, before=datetime.datetime.now()):
+def filter_entries(entries, after, before=None):
+    if before is None:
+        before = datetime.datetime.now()
     return [entry for entry in entries if entry[1] > after and entry[1] < before]
 
 


### PR DESCRIPTION
## Summary
- avoid using runtime expression as a default argument

## Testing
- `python -m compileall -q punch`

------
https://chatgpt.com/codex/tasks/task_e_6841a692362c8322af70d83a3dd10e5c