### PR TITLE
Add version flag

### DIFF
--- a/punch/__init__.py
+++ b/punch/__init__.py
@@ -3,6 +3,27 @@ import datetime
 import math
 import subprocess
 
+
+def _load_version():
+    """Return package version from metadata or setup.cfg."""
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        return version("punch")
+    except Exception:
+        import configparser
+        from pathlib import Path
+
+        config = configparser.ConfigParser()
+        cfg_path = Path(__file__).resolve().parent.parent / "setup.cfg"
+        if cfg_path.exists():
+            config.read(cfg_path)
+            return config.get("metadata", "version", fallback="0.0.0")
+        return "0.0.0"
+
+
+__version__ = _load_version()
+
 WORKDAY_START_TIME = datetime.time(6, 0, 0)
 WORKDAY_SECONDS = 8 * 60 * 60
 DAILY_HISTORY_LENGTH = datetime.timedelta(days=18)

--- a/punch/cli.py
+++ b/punch/cli.py
@@ -1,4 +1,5 @@
 from . import *
+from . import __version__
 import click
 import datetime
 
@@ -43,6 +44,7 @@ file_option = click.option(
 
 
 @click.group(invoke_without_command=True)
+@click.version_option(__version__)
 @click.pass_context
 @file_option
 def cli(ctx, path):

--- a/punch/cli.py
+++ b/punch/cli.py
@@ -43,10 +43,11 @@ file_option = click.option(
 )
 
 
-@click.group(invoke_without_command=True)
-@click.version_option(__version__)
-@click.pass_context
+@click.group(invoke_without_command=True, add_help_option=False)
 @file_option
+@click.pass_context
+@click.help_option()
+@click.version_option(__version__)
 def cli(ctx, path):
     """Simple command-line time tracker."""
     if ctx.invoked_subcommand is None:


### PR DESCRIPTION
## Summary
- expose the package version via setup.cfg metadata
- register `--version` option on the CLI

## Testing
- `python -m compileall -q punch`
- `python - <<'EOF'
import punch.cli as p
p.cli.main(['--version'])
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6841b3d22524832295fd6872f5782238