### PR TITLE
Add validation for consecutive entries

### DIFF
--- a/punch/__init__.py
+++ b/punch/__init__.py
@@ -345,6 +345,16 @@ def print_total_hours_for_period(path, history_start, history_end):
 
 
 def new_entry(path, timestamp, type):
+    all_entries = load_timesheet(path)
+    if len(all_entries) > 0:
+        last_type, last_timestamp = all_entries[-1]
+        if last_type == type:
+            print(
+                "Error: last entry was '{}' at {}".format(
+                    last_type, last_timestamp.strftime(TIMESTAMP_FORMAT)
+                )
+            )
+            return
     with open(path, "a") as timesheet:
         timesheet.write(timestamp.strftime(TIMESTAMP_FORMAT) + " " + type + "\n")
 


### PR DESCRIPTION
## Summary
- prevent adding two consecutive in/out entries and show timestamp of last entry

## Testing
- `python -m compileall -q punch`


------
https://chatgpt.com/codex/tasks/task_e_6841bf14a1c88322a51f0256eb968c05