### PR TITLE
Add export command

### DIFF
--- a/punch/__init__.py
+++ b/punch/__init__.py
@@ -2,6 +2,7 @@ import os
 import datetime
 import math
 import subprocess
+import json
 
 
 def _load_version():
@@ -384,3 +385,16 @@ def validate_timesheet(path):
             return
         expected_type = "out" if expected_type == "in" else "in"
     print("No errors")
+
+
+def export_entries_to_json(path, output_path):
+    if os.path.exists(output_path):
+        print(f"Error: {output_path} already exists")
+        return
+    entries = load_timesheet(path)
+    data = [
+        {"timestamp": timestamp.strftime(TIMESTAMP_FORMAT), "type": type}
+        for type, timestamp in entries
+    ]
+    with open(output_path, "w") as outfile:
+        json.dump(data, outfile, indent=2)

--- a/punch/cli.py
+++ b/punch/cli.py
@@ -121,6 +121,14 @@ def history(path):
 
 @cli.command()
 @file_option
+@click.argument("output", type=click.Path())
+def export(path, output):
+    """Export timesheet to JSON"""
+    export_entries_to_json(path, output)
+
+
+@cli.command()
+@file_option
 @click.argument("year", type=click.INT)
 def total(path, year):
     """Print total hours for the given year"""


### PR DESCRIPTION
## Summary
- add new `export` command that writes timesheet entries to a JSON file
- ensure the output file does not already exist

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846125cb19883228b3aa4f4cb7018a0