### PR TITLE
Implement JSON import command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ to point the tool at the timesheet file.
 - `punch daily` – histogram of days of the week
 - `punch weekly` – histogram by ISO week
 - `punch total YEAR` – total hours for a given year
+- `punch export FILE` – export timesheet to JSON
+- `punch import FILE` – import timesheet from JSON
 
 Running `punch` with no subcommand prints an overview of today's work.
 Punch assumes an 8‑hour workday starting at 06:00. The `punch hourly`,

--- a/punch/__init__.py
+++ b/punch/__init__.py
@@ -398,3 +398,36 @@ def export_entries_to_json(path, output_path):
     ]
     with open(output_path, "w") as outfile:
         json.dump(data, outfile, indent=2)
+
+
+def import_entries_from_json(path, input_path):
+    if os.path.exists(path):
+        print(f"Error: {path} already exists")
+        return
+    with open(input_path, "r") as infile:
+        try:
+            data = json.load(infile)
+        except Exception:
+            print(f"Error: could not load {input_path}")
+            return
+
+    entries = []
+    for item in data:
+        if not isinstance(item, dict) or "timestamp" not in item or "type" not in item:
+            print("Error: invalid entry in JSON file")
+            return
+        try:
+            timestamp = datetime.datetime.strptime(item["timestamp"], TIMESTAMP_FORMAT)
+        except Exception:
+            print(f"Error: invalid timestamp '{item.get('timestamp')}'")
+            return
+        if item["type"] not in ("in", "out"):
+            print(f"Error: invalid type '{item['type']}'")
+            return
+        entries.append((item["type"], timestamp))
+
+    with open(path, "w") as timesheet:
+        for type, timestamp in entries:
+            timesheet.write(f"{timestamp.strftime(TIMESTAMP_FORMAT)} {type}\n")
+
+    validate_timesheet(path)

--- a/punch/cli.py
+++ b/punch/cli.py
@@ -127,6 +127,14 @@ def export(path, output):
     export_entries_to_json(path, output)
 
 
+@cli.command(name="import")
+@file_option
+@click.argument("input", type=click.Path())
+def import_(path, input):
+    """Import timesheet from JSON"""
+    import_entries_from_json(path, input)
+
+
 @cli.command()
 @file_option
 @click.argument("year", type=click.INT)


### PR DESCRIPTION
## Summary
- add ability to import timesheets from JSON files
- expose `punch import` CLI command
- document import/export commands in README

## Testing
- `python -m py_compile punch/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68461a7557bc8322a3ac9d3e5066dce9