### PR TITLE
Add delete_last_entry implementation

### DIFF
--- a/punch/timesheet.py
+++ b/punch/timesheet.py
@@ -63,8 +63,15 @@ CREATE TABLE IF NOT EXISTS entries (
         self.conn.commit()
 
     def delete_last_entry(self):
-        # FIXME: implement
-        raise NotImplementedError
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT id FROM entries WHERE deleted = 0 ORDER BY timestamp DESC LIMIT 1"
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return
+        cursor.execute("UPDATE entries SET deleted = 1 WHERE id = ?", (row[0],))
+        self.conn.commit()
 
     def get_sessions_in_range(
         self, timestamp: datetime.datetime, delta: datetime.timedelta

--- a/tests/test_timesheet.py
+++ b/tests/test_timesheet.py
@@ -33,3 +33,45 @@ def test_add_entry_consecutive_same_type(tmp_path):
     timestamp += datetime.timedelta(minutes=1)
     with pytest.raises(MismatchedEntryException):
         sheet.add_entry(timestamp, "out")
+
+
+def test_delete_last_entry(tmp_path):
+    sheet = Timesheet(str(tmp_path / "sheet.db"))
+    ts = datetime.datetime.now().replace(microsecond=0)
+    sheet.add_entry(ts, "in")
+    ts += datetime.timedelta(minutes=1)
+    sheet.add_entry(ts, "out")
+    ts += datetime.timedelta(minutes=1)
+    sheet.add_entry(ts, "in")
+
+    sheet.delete_last_entry()
+
+    sessions = sheet.get_sessions_in_range(
+        ts - datetime.timedelta(minutes=3), datetime.timedelta(minutes=10)
+    )
+    assert len(sessions) == 1
+    assert sessions[0].get_start() == ts - datetime.timedelta(minutes=2)
+    assert sessions[0].get_end() == ts - datetime.timedelta(minutes=1)
+
+    ts += datetime.timedelta(minutes=1)
+    sheet.add_entry(ts, "in")
+
+    sessions = sheet.get_sessions_in_range(
+        ts - datetime.timedelta(minutes=4), datetime.timedelta(minutes=10)
+    )
+    assert len(sessions) == 2
+    assert sessions[0].get_start() == ts - datetime.timedelta(minutes=3)
+    assert sessions[0].get_end() == ts - datetime.timedelta(minutes=2)
+    assert sessions[1].get_start() == ts
+    assert sessions[1].get_end() is None
+
+
+def test_delete_last_entry_no_entries(tmp_path):
+    sheet = Timesheet(str(tmp_path / "sheet.db"))
+    sheet.delete_last_entry()
+    sessions = sheet.get_sessions_in_range(
+        datetime.datetime.now() - datetime.timedelta(hours=1),
+        datetime.timedelta(hours=2),
+    )
+    assert sessions == []
+


### PR DESCRIPTION
## Summary
- implement `Timesheet.delete_last_entry`
- test deletion behaviour
- refactor deletion tests to use `get_sessions_in_range`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849a9d6d0fc832282e441cd995af910